### PR TITLE
Fix bug when type is 'image/jpeg' or similar

### DIFF
--- a/src/ImageDropAndPaste.ts
+++ b/src/ImageDropAndPaste.ts
@@ -224,10 +224,10 @@ class ImageDropAndPaste extends QuillImageDropAndPaste {
   insert(content: string, type: string, index?: number): void {
     index = index === undefined ? this.getIndex() : index
     let _index: any
-    if (type === 'image') {
+    if (type.startsWith('image')) {
       _index = index + 1
-      this.quill.insertEmbed(index, type, content, 'user')
-    } else if (type === 'text') {
+      this.quill.insertEmbed(index, 'image', content, 'user')
+    } else if (type.startsWith('text')) {
       _index = index + content.length
       this.quill.insertText(index, content, 'user')
     }


### PR DESCRIPTION
Thanks for the plugin.

Without any custom `handler`, drag-drop of an image appears to work, but only because `quill` itself handles it. If one disables it, then it no longer works.

This happens because the code calls `insert` with `type` as a mime type like `"image/jpeg"` which then gets ignored. Am I mistaken in thinking that the intention was for the plugin to handle this?

Possibly related to #54